### PR TITLE
Fix for diorite and emery platforms

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -3,7 +3,7 @@
   "shortName": "OW Camera Remote",
   "longName": "OW Camera Remote",
   "companyName": "jamsinclair",
-  "versionLabel": "1.1",
+  "versionLabel": "1.2",
   "sdkVersion": "3",
   "targetPlatforms": ["aplite", "basalt", "chalk", "diorite", "emery"],
   "watchapp": {

--- a/appinfo.json
+++ b/appinfo.json
@@ -5,7 +5,7 @@
   "companyName": "jamsinclair",
   "versionLabel": "1.1",
   "sdkVersion": "3",
-  "targetPlatforms": ["aplite", "basalt", "chalk"],
+  "targetPlatforms": ["aplite", "basalt", "chalk", "diorite", "emery"],
   "watchapp": {
     "watchface": false
   },

--- a/src/comm/comm.c
+++ b/src/comm/comm.c
@@ -23,6 +23,7 @@ static char *translate_error(AppMessageResult result) {
     case APP_MSG_OUT_OF_MEMORY: return "APP_MSG_OUT_OF_MEMORY";
     case APP_MSG_CLOSED: return "APP_MSG_CLOSED";
     case APP_MSG_INTERNAL_ERROR: return "APP_MSG_INTERNAL_ERROR";
+    case APP_MSG_INVALID_STATE: return "APP_MSG_INVALID_STATE";
     default: return "UNKNOWN ERROR";
   }
 }

--- a/src/windows/alert_window.h
+++ b/src/windows/alert_window.h
@@ -2,7 +2,7 @@
 
 #include <pebble.h>
 
-#define DIALOG_MESSAGE_WINDOW_MESSAGE  "Unable to talk with android app. Please open 'OW Camera' on your phone"
+#define DIALOG_MESSAGE_WINDOW_MESSAGE  "Unable to talk with Android app. Please open 'OW Camera' on your phone"
 #define DIALOG_MESSAGE_WINDOW_MARGIN   10
 
 void alert_window_push();

--- a/src/windows/alert_window.h
+++ b/src/windows/alert_window.h
@@ -2,7 +2,7 @@
 
 #include <pebble.h>
 
-#define DIALOG_MESSAGE_WINDOW_MESSAGE  "Unable to talk with app. Is 'OW Camera' Android app running?"
+#define DIALOG_MESSAGE_WINDOW_MESSAGE  "Unable to talk with android app. Please open 'OW Camera' on your phone"
 #define DIALOG_MESSAGE_WINDOW_MARGIN   10
 
 void alert_window_push();


### PR DESCRIPTION
Changes:
- Add builds for 'diorite' and 'emery' platforms
- Update error text to hopefully make it clearer to open the Android Companion app `Ow Camera for Pebble`
- Add new switch case to log any `APP_MSG_INVALID_STATE` errors (seem to happen on the aplite platform)
