### PR TITLE
fix: rendering of image previews on chalk devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "OW Camera Remote 2",
   "author": "jamsinclair",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "keywords": [
     "pebble-app"

--- a/src/app_settings.h
+++ b/src/app_settings.h
@@ -6,6 +6,7 @@ typedef struct {
   char model_name[16];
   uint16_t screen_width;
   uint16_t screen_height;
+  uint16_t action_bar_width;
   uint8_t dithering_algorithm;
   uint16_t timer_seconds;
   uint8_t color_format;

--- a/src/main.c
+++ b/src/main.c
@@ -21,6 +21,7 @@ AppSettings* app_get_settings() {
 static void detect_watch_model() {
   g_app_settings.screen_width = PBL_DISPLAY_WIDTH;
   g_app_settings.screen_height = PBL_DISPLAY_HEIGHT;
+  g_app_settings.action_bar_width = PBL_IF_RECT_ELSE(ACTION_BAR_WIDTH, 28);
 
 #ifdef PBL_PLATFORM_APLITE
   strcpy(g_app_settings.model_name, "aplite");

--- a/src/preview/frame_buffer_manager.c
+++ b/src/preview/frame_buffer_manager.c
@@ -39,7 +39,7 @@ bool frame_buffer_manager_init_with_format(FrameFormat format) {
 
   // Calculate frame size: screen dimensions minus action bar width (side action bar)
   uint16_t frame_height = settings->screen_height;
-  uint16_t frame_width = settings->screen_width - TIMER_OVERLAY_HEIGHT;
+  uint16_t frame_width = settings->screen_width - settings->action_bar_width;
 
   if (frame_height <= 0 || frame_width <= 0) {
     APP_LOG(APP_LOG_LEVEL_ERROR, "frame_buffer_manager: Invalid dimensions %ux%u",

--- a/src/preview/frame_buffer_manager.h
+++ b/src/preview/frame_buffer_manager.h
@@ -1,9 +1,6 @@
 #pragma once
 #include <pebble.h>
 
-// Timer overlay height used across the app
-#define TIMER_OVERLAY_HEIGHT 30
-
 // Frame format enum (extensible for future color support)
 typedef enum {
   FRAME_FORMAT_1BIT_BW = 0,    // 1-bit black & white

--- a/src/preview/message_assembler.c
+++ b/src/preview/message_assembler.c
@@ -323,38 +323,42 @@ bool message_assembler_process(
     return false;
   }
 
-  // Try to parse as first message
-  FirstMessageHeader first_header;
-  if (parse_first_message_header(msg_data, msg_length, &first_header)) {
-    // Validate format matches allocated buffer
-    FrameFormat expected_format = frame_buffer_manager_get_format();
-    if ((expected_format == FRAME_FORMAT_1BIT_BW && first_header.format != MESSAGE_FORMAT_1BIT_BW) ||
-        (expected_format == FRAME_FORMAT_4BIT_COLOR && first_header.format != MESSAGE_FORMAT_4BIT_COLOR)) {
-      APP_LOG(APP_LOG_LEVEL_ERROR, "message_assembler: format mismatch (expected=%d, received=%d)",
-              expected_format, first_header.format);
+  uint8_t header_byte = msg_data[0];
+
+  if (header_byte & 0x01) {
+    // Continuation message (bit 0 = 1)
+    ContinuationHeader cont_header;
+    if (!parse_continuation_header(msg_data, msg_length, &cont_header)) {
+      APP_LOG(APP_LOG_LEVEL_ERROR, "message_assembler: failed to parse continuation header");
       return false;
     }
-
-    if (first_header.multi_message) {
-      // Multi-message sequence - start accumulation
-      return handle_multi_message_first(&first_header);
-    } else {
-      // Single message - process immediately
-      if (first_header.format == MESSAGE_FORMAT_1BIT_BW) {
-        return handle_1bit_single_message(&first_header, callback);
-      } else if (first_header.format == MESSAGE_FORMAT_4BIT_COLOR) {
-        return handle_4bit_single_message(&first_header, callback);
-      }
-    }
-    return true;
-  }
-
-  // Try to parse as continuation message
-  ContinuationHeader cont_header;
-  if (parse_continuation_header(msg_data, msg_length, &cont_header)) {
     return handle_continuation_message(&cont_header, callback);
   }
 
-  APP_LOG(APP_LOG_LEVEL_ERROR, "message_assembler: unable to parse as first or continuation");
-  return false;
+  // First message (bit 0 = 0)
+  FirstMessageHeader first_header;
+  if (!parse_first_message_header(msg_data, msg_length, &first_header)) {
+    return false;
+  }
+
+  // Validate format matches allocated buffer
+  FrameFormat expected_format = frame_buffer_manager_get_format();
+  if ((expected_format == FRAME_FORMAT_1BIT_BW && first_header.format != MESSAGE_FORMAT_1BIT_BW) ||
+      (expected_format == FRAME_FORMAT_4BIT_COLOR && first_header.format != MESSAGE_FORMAT_4BIT_COLOR)) {
+    APP_LOG(APP_LOG_LEVEL_ERROR, "message_assembler: format mismatch (expected=%d, received=%d)",
+            expected_format, first_header.format);
+    return false;
+  }
+
+  if (first_header.multi_message) {
+    return handle_multi_message_first(&first_header);
+  }
+
+  if (first_header.format == MESSAGE_FORMAT_1BIT_BW) {
+    return handle_1bit_single_message(&first_header, callback);
+  } else if (first_header.format == MESSAGE_FORMAT_4BIT_COLOR) {
+    return handle_4bit_single_message(&first_header, callback);
+  }
+
+  return true;
 }

--- a/src/windows/preview_window.c
+++ b/src/windows/preview_window.c
@@ -470,7 +470,7 @@ static void preview_window_load(Window *window) {
 
   // Create canvas layer for frames (accounting for action bar width on rect displays)
   GRect canvas_bounds = GRect(0, 0,
-                               bounds.size.w - PBL_IF_RECT_ELSE(ACTION_BAR_WIDTH, 0),
+                               bounds.size.w - app_get_settings()->action_bar_width,
                                bounds.size.h);
   s_canvas_layer = layer_create(canvas_bounds);
   layer_set_update_proc(s_canvas_layer, canvas_update_proc);


### PR DESCRIPTION
Changes:

- Fix buffer overlay by properly accounting for smaller action bar width on chalk devices
- Simplify handling of multi-messages to prevent not reading chunked messages correctly
- Remove unused constant